### PR TITLE
Fix code scanning alert no. 1: Use of insecure SSL/TLS version

### DIFF
--- a/python/admin/nginx_load_test.py
+++ b/python/admin/nginx_load_test.py
@@ -143,6 +143,7 @@ def perform_ssl_check(url: str) -> None:
     print(f"\nSSL Certificate Check for {hostname}:")
     try:
         context = ssl.create_default_context()
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         with socket.create_connection((hostname, port)) as sock:
             with context.wrap_socket(sock, server_hostname=hostname) as secure_sock:
                 cert = secure_sock.getpeercert()


### PR DESCRIPTION
Fixes [https://github.com/Searge/shell/security/code-scanning/1](https://github.com/Searge/shell/security/code-scanning/1)

To fix the problem, we need to ensure that the SSL context explicitly uses a secure version of TLS (1.2 or above). This can be done by setting the `minimum_version` attribute of the SSL context to `ssl.TLSVersion.TLSv1_2`. This change ensures that only TLS 1.2 and above are used, mitigating the risk of using insecure protocols.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
